### PR TITLE
Update import.py to handle task without tags or due and to set correct task status

### DIFF
--- a/import.py
+++ b/import.py
@@ -19,14 +19,25 @@ if sys.argv[1] == 'taskwarrior':
     database_out = open('.database', 'w')
 
     def parse_due(raw_due):
-        due = datetime.strptime(raw_due, '%Y%m%dT%H%M%SZ')
-        return due.strftime('%s')
+        if raw_due:
+            due = datetime.strptime(raw_due, '%Y%m%dT%H%M%SZ')
+            return due.strftime('%s')
+        return raw_due
+
+    def parse_status(status):
+        if status == 'completed' or status == 'deleted':
+            return 1
+        return 0
 
     for line in database_in.read().split('\n'):
         try:
             task = json.loads(line)
-            if task['status'] != 'pending':
-                continue
+
+            if 'tags' not in task.keys():
+                task['tags'] = []
+
+            if 'due' not in task.keys():
+                task['due'] = ''
 
             tasks[task['uuid']] = {
                 'desc': task['description'],
@@ -36,7 +47,7 @@ if sys.argv[1] == 'taskwarrior':
                 'start': [],
                 'stop': [],
                 'active': 0,
-                'done': 0,
+                'done': parse_status(task['status'])
             }
 
         except:


### PR DESCRIPTION
Thanks for creating this script for importing taskwarrior data.

I found some issues when importing data from `backlog.data`

1. Some tasks haven't `tags` or `due` filed at all, for example:
```
{"description":"something else","entry":"20190512T151815Z","modified":"20190512T151815Z","status":"pending","uuid":"023f2695-bed8-4def-ac97-6c93d0132e82"}
```

2. Same task can have multiple lines with different `status` in `backlog.data`, like:
```
...
{"description":"new","due":"20190518T215959Z","entry":"20190512T121339Z","modified":"20190512T121339Z","status":"pending","uuid":"410c8ac5-e2c4-48a4-8bed-2aa9e85bc51a"}
...
{"description":"new","due":"20190518T215959Z","end":"20190512T142718Z","entry":"20190512T121339Z","modified":"20190512T142719Z","status":"deleted","uuid":"410c8ac5-e2c4-48a4-8bed-2aa9e85bc51a"}
...
```

So, I updated `import.py` to handle the cases that `tags` and `due` are missing. Also, because I noticed that `task['uuid']` is used as key to construct the object, and the latest status of a task appearing closer to the bottom of `backlog.data` file. So, I decided to let the latest status of a task overwrite the previous one, considering "completed" and "deleted" as "done".

Please review the code and let me know if you have any questions.